### PR TITLE
Address memory leaks

### DIFF
--- a/test.c
+++ b/test.c
@@ -4,14 +4,21 @@ int main()
 {
     XMLDocument doc;
     if (XMLDocument_load(&doc, "test.xml")) {
+        char fields_buff[1024] = { 0 };
         XMLNode* str = XMLNode_child(doc.root, 0);
 
         XMLNodeList* fields = XMLNode_children(str, "field");
         for (int i = 0; i < fields->size; i++) {
             XMLNode* field = XMLNodeList_at(fields, i);
             XMLAttribute* type = XMLNode_attr(field, "type");
-            type->value = "";
+            snprintf(fields_buff, 1024, "%s %s\n", type->key, type->value);
         }
+
+        free(fields->data);
+        fields->data = NULL;
+
+        free(fields);
+        fields = NULL;
 
         XMLDocument_write(&doc, "out.xml", 4);
         XMLDocument_free(&doc);


### PR DESCRIPTION
Addresses memory related problems, both from 'Double Free Corruption' but also non-free'd memory.

 * Values set to `NULL` after free
   *  Avoids `Double Free Corruption`
 * Values in `Linked-List` free'd when parent element is free'd
 * Remove `NULL` dereference when there were no `children` elements to obtain
 * Deep clone of `attrVal` made in order to simplify `free` calls
 * `buf` free'd
 * `test.c` refactored:
   * No longer re-assigned `heap-allocated` address space
   * Values free'd appropriately
 * Address `GCC`/`GNU` compiler warnings